### PR TITLE
fix(Search/Profile): Redirect to your own profile from search page

### DIFF
--- a/src/containers/Profile.jsx
+++ b/src/containers/Profile.jsx
@@ -48,6 +48,8 @@ class Profile extends Component {
       this.context.router.push('/login');
     } else if (!visitedUser && getUsername() !== nextProps.profile.username) {
       this.props.getUser(getUsername());
+    } else if (visitedUser === getUsername()) {
+      this.context.router.push('/');
     }
   }
 


### PR DESCRIPTION
Fix an issue where clicking your own profile from the search page will redirect to your own 'profile
page' as if you are visiting someone else's  ie: /profile/yourOwnUserName. Now it correctly redirects to the root. 